### PR TITLE
Improved (un)selected colours

### DIFF
--- a/src/app/styles/talent.scss
+++ b/src/app/styles/talent.scss
@@ -14,7 +14,7 @@
   display: inline-block;
   width: var(--cell-size);
   height: var(--cell-size);
-  background-color: #508852;
+  background-color: #203821;
   box-sizing: border-box;
   padding: calc(var(--border));
   cursor: pointer;
@@ -59,7 +59,7 @@
 }
 
 .max {
-  background-color: #c0b162;
+  background-color: #ffea81;
 }
 
 .gray {


### PR DESCRIPTION
I improved the (un)selected talent circle colours so they can be seen better by colour-impaired people like me.

Before:
![image](https://user-images.githubusercontent.com/1854749/198840553-21cf6780-3956-414d-b6aa-fc5d65cf2ea1.png)

After:
![image](https://user-images.githubusercontent.com/1854749/198840565-fa626f15-9296-4af7-bf88-80ccd71367ee.png)

Note that the colours I chose were completely random :) The main point is that the unselected colour should be darker, and the selected colour should be much brighter.

Thanks for making a great page!